### PR TITLE
Updated .gitignore to Not Include Binary Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 *.userosscache
 *.sln.docstates
 
+# User provided files for this project
+*.bin
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 


### PR DESCRIPTION
This adds:
*.bin
to the .gitignore to prevent the upload of non-project code binary data